### PR TITLE
Remove -r option from rm command

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -920,11 +920,11 @@ s.file=function(x,e){
         break;
         case'delete':
             if(!e){return false;}
-            return exec('rm -rf '+e,{detached: true});
+            return exec('rm -f '+e,{detached: true});
         break;
         case'delete_files':
             if(!e.age_type){e.age_type='min'};if(!e.age){e.age='1'};
-            exec('find '+e.path+' -type f -c'+e.age_type+' +'+e.age+' -exec rm -rf {} +',{detached: true});
+            exec('find '+e.path+' -type f -c'+e.age_type+' +'+e.age+' -exec rm -f {} +',{detached: true});
         break;
     }
 }


### PR DESCRIPTION
Please remove -r option (recursive) as it is not needed and also dangerous. In many setups Shinobi is running as root and in case of a software failure it could delete the whole file system of the host.