### PR TITLE
crypto: This package is no longer supported. It's now a built-in Node module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "body-parser": "^1.15.2",
     "circular-json": "0.3.1",
     "connection-tester": "^0.1.1",
-    "crypto": "^0.0.3",
     "ejs": "^2.5.5",
     "express": "^4.14.0",
     "jsonfile": "^3.0.1",


### PR DESCRIPTION
As it is a built-in Node module in the minimum required Node.js (7.2.0), this line can be removed and the warning in the compile will be away :-) 