### PR TITLE
Move fullscreen to match main.dash2.js layout

### DIFF
--- a/web/pages/blocks/powervideo.ejs
+++ b/web/pages/blocks/powervideo.ejs
@@ -31,11 +31,11 @@
                     <div class="btn-group btn-group-sm">
                         <a preview="stepBackBack" class="active btn btn-primary"><i class="fa fa-backward"></i></a>
                         <a preview="stepBack" class="btn btn-primary"><i class="fa fa-arrow-circle-o-left"></i></a>
-                        <a preview="fullscreen" class="btn btn-default"><i class="fa fa-arrows-alt"></i></a>
                         <a preview="play" class="btn btn-default"><i class="fa fa-play"></i></a>
                         <a preview="mute" class="btn btn-default"><i class="fa fa-volume-up"></i></a>
                         <a preview="stepFront" class="btn btn-primary"><i class="fa fa-arrow-circle-o-right"></i></a>
                         <a preview="stepFrontFront" class="active btn btn-primary"><i class="fa fa-forward"></i></a>
+                        <a preview="fullscreen" class="btn btn-default"><i class="fa fa-arrows-alt"></i></a>
                     </div>
                     <div class="btn-group">
                         <a onclick="$.pwrvid.f.submit()" class="active btn btn-success"><i class="fa fa-refresh"></i></a>


### PR DESCRIPTION
This makes more sense to me. I keep trying to full screen the power viewer and I find myself having to look for the full screen button all the time.