### PR TITLE
Fixes pop-out player when using proxies

### DIFF
--- a/web/libs/js/main.dash2.js
+++ b/web/libs/js/main.dash2.js
@@ -3630,7 +3630,7 @@ $('body')
                 if($.ccio.mon[e.ke+e.mid+user.auth_token].popOut){
                     $.ccio.mon[e.ke+e.mid+user.auth_token].popOut.close()
                 }
-                $.ccio.mon[e.ke+e.mid+user.auth_token].popOut = window.open($.ccio.init('location',user)+user.auth_token+'/embed/'+e.ke+'/'+e.mid+'/fullscreen|jquery|gui','pop_'+e.mid+user.auth_token,'height='+img.height+',width='+img.width);
+                $.ccio.mon[e.ke+e.mid+user.auth_token].popOut = window.open($.ccio.init('location',user)+user.auth_token+'/embed/'+e.ke+'/'+e.mid+'/fullscreen|jquery|relative|gui','pop_'+e.mid+user.auth_token,'height='+img.height+',width='+img.width);
             }
             if(e.mon.watch===1){
                 $.ccio.snapshot(e,function(url){


### PR DESCRIPTION
Per discussion in discord chat, add the `relative` flag to the link for the pop-out player. This fixes a bug where the stream cannot be found and the pop-up window is blank.