### PR TITLE
Detector max sensitivity and frame skip threshold

### DIFF
--- a/definitions/en_CA.json
+++ b/definitions/en_CA.json
@@ -878,6 +878,22 @@
                   "possible": ""
                },
                {
+                  "name": "detail=detector_max_sensitivity",
+                  "field": "Max Indifference",
+                  "description": "An upperbound to indifference. Any value over this amount will be ignored.",
+                  "default": "",
+                  "example": "75",
+                  "possible": "Any number."
+               },
+               {
+                  "name": "detail=detector_threshold",
+                  "field": "Trigger Threshold",
+                  "description": "Minimum number of detections to fire a motion event. Detections must be within the detector the threshold divided by detector fps seconds. For example, if detector fps is 2 and trigger threshold is 3, then three detections must occur within 1.5 seconds to trigger a motion event. This threshold is per detection region.",
+                  "default": "1",
+                  "example": "3",
+                  "possible": "Any non-negative integer."
+               },
+               {
                   "name": "detail=detector_webhook",
                   "field": "Webhook",
                   "description": "Send a GET request to a URL with some values from the event.",

--- a/languages/en_CA.json
+++ b/languages/en_CA.json
@@ -167,6 +167,8 @@
    "RegionNote": "Points are only saved when you press <b>Save</b> on the <b>Monitor Settings</b> window.",
    "Points": "Points <small>When adding points click on the edge of the polygon.</small>",
    "Indifference": "Indifference",
+   "Max Indifference": "Max Indifference",
+   "Trigger Threshold": "Trigger Threshold",
    "Region Name": "Region Name",
    "Regions": "Regions",
    "Again": "Again",

--- a/web/libs/js/main.dash2.js
+++ b/web/libs/js/main.dash2.js
@@ -2634,6 +2634,8 @@ $.zO.initCanvas=function(){
     if(!e.val){
         $.zO.f.find('[name="name"]').val('')
         $.zO.f.find('[name="sensitivity"]').val('')
+        $.zO.f.find('[name="max_sensitivity"]').val('')
+        $.zO.f.find('[name="threshold"]').val('')
         $.zO.rp.empty()
     }else{
         e.cord=$.zO.regionViewerDetails.cords[e.val];
@@ -2647,6 +2649,8 @@ $.zO.initCanvas=function(){
         $.zO.f.find('[name="name"]').val(e.val)
         $.zO.e.find('.cord_name').text(e.val)
         $.zO.f.find('[name="sensitivity"]').val(e.cord.sensitivity)
+        $.zO.f.find('[name="max_sensitivity"]').val(e.cord.max_sensitivity)
+        $.zO.f.find('[name="threshold"]').val(e.cord.threshold)
         $.zO.e.find('.canvas_holder canvas').remove();
         
         $.zO.initLiveStream()
@@ -2664,6 +2668,16 @@ $.zO.initCanvas=function(){
 $.zO.e.on('change','[name="sensitivity"]',function(e){
     e.val=$(this).val();
     $.zO.regionViewerDetails.cords[$.zO.rl.val()].sensitivity=e.val;
+    $.zO.saveCoords()
+})
+$.zO.e.on('change','[name="max_sensitivity"]',function(e){
+    e.val=$(this).val();
+    $.zO.regionViewerDetails.cords[$.zO.rl.val()].max_sensitivity=e.val;
+    $.zO.saveCoords()
+})
+$.zO.e.on('change','[name="threshold"]',function(e){
+    e.val=$(this).val();
+    $.zO.regionViewerDetails.cords[$.zO.rl.val()].threshold=e.val;
     $.zO.saveCoords()
 })
 $.zO.e.on('change','[name="name"]',function(e){
@@ -2749,7 +2763,7 @@ $.zO.e.on('click','.add',function(e){
         }
     })
     $.zO.regionViewerDetails.cords=e.save;
-    $.zO.regionViewerDetails.cords[e.gid]={name:e.gid,sensitivity:0.0005,points:[[0,0],[0,100],[100,0]]};
+    $.zO.regionViewerDetails.cords[e.gid]={name:e.gid,sensitivity:0.0005,max_sensitivity:'',threshold:1,points:[[0,0],[0,100],[100,0]]};
     $.zO.rl.append('<option value="'+e.gid+'">'+e.gid+'</option>');
     $.zO.rl.val(e.gid)
     $.zO.rl.change();
@@ -3144,6 +3158,8 @@ $.aM.generateDefaultMonitorSettings=function(){
         "detector_use_detect_object": "0",
         "detector_frame": "0",
         "detector_sensitivity": "",
+        "detector_max_sensitivity": "",
+        "detector_threshold": "1",
         "cords": "[]",
         "detector_buffer_vcodec": "auto",
         "detector_buffer_fps": "",
@@ -5007,7 +5023,7 @@ $('body')
             }
             if(!e.d.cords||e.d.cords===''){
                 e.d.cords={
-                    red:{ name:"red",sensitivity:0.0005, points:[[0,0],[0,100],[100,0]] },
+                    red:{ name:"red",sensitivity:0.0005, max_sensitivity:"",points:[[0,0],[0,100],[100,0]] },
                 }
             }
             $.zO.regionViewerDetails=e.d;

--- a/web/pages/blocks/monitoredit.ejs
+++ b/web/pages/blocks/monitoredit.ejs
@@ -998,6 +998,16 @@
                         </label>
                       </div>
                       <div class="form-group">
+                        <label><div><span><%-lang['Max Indifference']%></span></div>
+                        <div><input class="form-control" detail="detector_max_sensitivity" placeholder=""></div>
+                        </label>
+                      </div>
+                      <div class="form-group">
+                        <label><div><span><%-lang['Trigger Threshold']%></span></div>
+                        <div><input class="form-control" detail="detector_threshold" placeholder="1"></div>
+                        </label>
+                      </div>
+                      <div class="form-group">
                         <label><div><span><%-lang['Full Frame Detection']%></span></div>
                             <div><select class="form-control" detail="detector_frame">
                                 <option value="0"><%-lang.No%></option>

--- a/web/pages/blocks/region.ejs
+++ b/web/pages/blocks/region.ejs
@@ -33,8 +33,20 @@
                     </div>
                     <div class="form-group col-md-12">
                         <label>
-                            <div><span><%-lang.Indifference%></span></div>
+                            <div><span><%-lang['Indifference']%></span></div>
                             <div><input class="form-control" name="sensitivity"></div>
+                        </label>
+                    </div>
+                    <div class="form-group col-md-12">
+                        <label>
+                            <div><span><%-lang['Max Indifference']%></span></div>
+                            <div><input class="form-control" name="max_sensitivity"></div>
+                        </label>
+                    </div>
+                    <div class="form-group col-md-12">
+                        <label>
+                            <div><span><%-lang['Trigger Threshold']%></span></div>
+                            <div><input class="form-control" name="threshold"></div>
                         </label>
                     </div>
                 </div>


### PR DESCRIPTION
Adds ability to add global/per region max sensitivity, above which detections are ignored. 
Adds ability to set a global/per region detector threshold, a number of frames within the sensitivity (min and optionally max) before trigging a record, time bounded by threshold divided by detector fps seconds. 