### PR TITLE
Run Node setup as sudo.

### DIFF
--- a/INSTALL/ubuntu.sh
+++ b/INSTALL/ubuntu.sh
@@ -19,7 +19,7 @@ read nodejsinstall
 if [ "$nodejsinstall" = "y" ] || [ "$nodejsinstall" = "Y" ]; then
     wget https://deb.nodesource.com/setup_8.x
     chmod +x setup_8.x
-    ./setup_8.x
+    sudo ./setup_8.x
     sudo apt install nodejs -y
 fi
 echo "============="


### PR DESCRIPTION
Without this change, I ended up with nodejs 4.2.6 from Canonical with no NPM, and other parts of the installation bombed out in non-obvious ways.