### PR TITLE
Install software-properties-common to get the add-apt-repository tool

### DIFF
--- a/INSTALL/ubuntu.sh
+++ b/INSTALL/ubuntu.sh
@@ -38,6 +38,7 @@ if [ "$ffmpeginstall" = "y" ] || [ "$ffmpeginstall" = "Y" ]; then
     if [[ "$getubuntuversion" == "16" || "$getubuntuversion" < "16" ]]; then
         echo "============="
         echo "Shinobi - Get FFMPEG 3.x from ppa:jonathonf/ffmpeg-3"
+        sudo apt install software-properties-common
         sudo add-apt-repository ppa:jonathonf/ffmpeg-3 -y
         sudo apt update -y && sudo apt install ffmpeg libav-tools x264 x265 -y
         echo "============="


### PR DESCRIPTION
On a minimal environment like a container, the add-apt-repository invocation fails and you end up with ffmpeg 2.8.11 from Canonical.