### PR TITLE
ffmpeg-static existence issue

### DIFF
--- a/camera.js
+++ b/camera.js
@@ -17,7 +17,8 @@ var ffmpegPath = false;
 try{
     ffmpegPath = require('ffmpeg-static').path;
     if (!fs.existsSync(ffmpegPath)) {
-	    throw "FFMpeg doesn't exist!"
+	 console.log('"ffmpeg-static" from NPM has failed to provide a compatible library or has been corrupted.')
+	 console.log('You may need to install FFmpeg manually or you can try running "npm uninstall ffmpeg-static && npm install ffmpeg-static".')
     }
 }catch(err){
     ffmpegPath = false;

--- a/camera.js
+++ b/camera.js
@@ -17,7 +17,7 @@ var ffmpegPath = false;
 try{
     ffmpegPath = require('ffmpeg-static').path;
     if (!fs.existsSync(ffmpegPath)) {
-	    throw "file doesn't exist!"
+	    throw "FFMpeg doesn't exist!"
     }
 }catch(err){
     ffmpegPath = false;

--- a/camera.js
+++ b/camera.js
@@ -20,6 +20,7 @@ try{
 	    throw "file doesn't exist!"
     }
 }catch(err){
+    ffmpegPath = false;
     console.log('No Static FFmpeg. Continuing.')
     //no static ffmpeg
 }

--- a/camera.js
+++ b/camera.js
@@ -8,6 +8,7 @@
 // If you like what I am doing here and want me to continue please consider donating :)
 // PayPal : paypal@m03.ca
 //
+var fs = require('fs');
 process.on('uncaughtException', function (err) {
     console.error('Uncaught Exception occured!');
     console.error(err.stack);
@@ -15,11 +16,13 @@ process.on('uncaughtException', function (err) {
 var ffmpegPath = false;
 try{
     ffmpegPath = require('ffmpeg-static').path;
+    if (!fs.existsSync(ffmpegPath)) {
+	    throw "file doesn't exist!"
+    }
 }catch(err){
     console.log('No Static FFmpeg. Continuing.')
     //no static ffmpeg
 }
-var fs = require('fs');
 var os = require('os');
 var URL = require('url');
 var path = require('path');


### PR DESCRIPTION
Linskin had an issue with his Rasp Pi install.
http://paste.debian.net/1019783/

For some reason `ffmpegPath = require('ffmpeg-static').path;` was still returning  `/home/pi/Shinobi/node_modules/ffmpeg-static/bin/linux/arm/ffmpeg` regardless of that file not actually existing.

> [3:06 PM] Linskin: 
> root@raspberrypi:/home/pi/Shinobi# ls node_modules/ffmpeg-static/bin/linux/
> ia32  x64


Now, this did fix the issue. I just don't know how you actually want to handle it. This was just what I made for him quickly.